### PR TITLE
Fix typo in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ endif()
 #---------------------------------
 # add samples
 #---------------------------------
-if(NOT DEFINED ENABLE_SAMPELS)
+if(NOT DEFINED ENABLE_SAMPLES)
     set(ENABLE_SAMPLES FALSE CACHE BOOL "Enable to make the samples")
 endif()
 


### PR DESCRIPTION
There is a typo in file CMakeList.txt
